### PR TITLE
Fixed URP/SimpleLit Shader

### DIFF
--- a/Assets/SDK/AddressableAssetsData/SdkShadersHD.asset
+++ b/Assets/SDK/AddressableAssetsData/SdkShadersHD.asset
@@ -27,6 +27,11 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels:
     - Windows
+  - m_GUID: 8d2bb70cbf9db8d4da26e15b26e74248
+    m_Address: Shader.URP.SimpleLit
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Windows
   m_ReadOnly: 0
   m_Settings: {fileID: 11400000, guid: b14c4d9d8b63f3247be008fe8b53d3ae, type: 2}
   m_SchemaSet:


### PR DESCRIPTION
This change adds the SimpleLit shader to the SdkShadersHD bundle, where SimpleLit is located in the base game. Doing so allows users to use the SimpleLit shader without it appearing pink ingame, and still without having to bake it's variants.

It's possible SimpleLit was not intended to be included in the HD bundle in base game, regardless this change will fix the issue until/if it's changed in a future update.