### PR TITLE
Fixed Item Book Canvas Scale

### DIFF
--- a/Assets/SDK/Scenes/Prefabs/UI_ItemSpawner.prefab
+++ b/Assets/SDK/Scenes/Prefabs/UI_ItemSpawner.prefab
@@ -114,8 +114,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 180}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.11, y: 0}
-  m_SizeDelta: {x: 0.18, y: 0.05}
+  m_AnchoredPosition: {x: -33.1, y: 0}
+  m_SizeDelta: {x: 54.1, y: 63.7}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3707849514138173799
 CanvasRenderer:
@@ -1376,7 +1376,7 @@ RectTransform:
   m_GameObject: {fileID: 2623981220760101318}
   m_LocalRotation: {x: -0, y: -0, z: -0.00000008429368, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.6, y: 0.6000003, z: 0.5999998}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8783591594200871808}
   - {fileID: 6038700377052233876}
@@ -1385,8 +1385,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0.1668}
-  m_SizeDelta: {x: 0.03, y: 0.03}
+  m_AnchoredPosition: {x: 0, y: -21}
+  m_SizeDelta: {x: 8.97, y: 35.29}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8342916907371322518
 CanvasRenderer:
@@ -1650,8 +1650,8 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2992642136568529068}
   m_LocalRotation: {x: 0.00000009945961, y: 1, z: 0.000000057974805, w: -0.00000001181502}
-  m_LocalPosition: {x: 0, y: 0, z: -0}
-  m_LocalScale: {x: 3999.999, y: 3999.999, z: 4166.6675}
+  m_LocalPosition: {x: 0, y: 0, z: -0.000004580799}
+  m_LocalScale: {x: 8, y: 2, z: 1}
   m_Children:
   - {fileID: 8778283907304197140}
   - {fileID: 1184905048121146726}
@@ -1660,7 +1660,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 50, y: -714}
+  m_AnchoredPosition: {x: 49.999924, y: -5.4000244}
   m_SizeDelta: {x: -850, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &3066987544040945067
@@ -2152,17 +2152,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3837364566519642095}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 1, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1184905048121146726}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 180}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.11, y: 0}
-  m_SizeDelta: {x: 0.18, y: 0.05}
+  m_AnchoredPosition: {x: 33.1, y: 0}
+  m_SizeDelta: {x: 54.1, y: 63.7}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5006576535037395994
 CanvasRenderer:
@@ -2990,8 +2990,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0.0014948845, y: -0.00023514964}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0.0014948845, y: -0.0002961848}
+  m_SizeDelta: {x: 0, y: 251}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &8419655475265620893
 MonoBehaviour:
@@ -3571,7 +3571,6 @@ MonoBehaviour:
   containerID: 
   saveOnLevelUnload: 0
   saveToPlayerContainerID: 
-  contents: []
 --- !u!1 &5271650941922790419
 GameObject:
   m_ObjectHideFlags: 0
@@ -4441,8 +4440,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.000061035156, y: -0.00018310547}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -0.000061035156, y: 0.00030517578}
+  m_SizeDelta: {x: 0, y: 589.6}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &622516657140806688
 MonoBehaviour:
@@ -6239,15 +6238,15 @@ RectTransform:
   m_GameObject: {fileID: 7590188698773065392}
   m_LocalRotation: {x: -0.00000008429369, y: -1, z: -0.00000023841852, w: -0.000000010536698}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.00025000004, y: 0.00025000004, z: 0.00023999996}
+  m_LocalScale: {x: 0.12512629, y: 0.49, z: 0.00023999996}
   m_Children: []
   m_Father: {fileID: 7590188699557635165}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0.1875}
-  m_SizeDelta: {x: 750, y: 200}
+  m_AnchoredPosition: {x: 0.17, y: 20.5}
+  m_SizeDelta: {x: 900, y: 200}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7590188698773065397
 CanvasRenderer:
@@ -6517,8 +6516,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 180}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.11, y: 0}
-  m_SizeDelta: {x: 0.18, y: 0.05}
+  m_AnchoredPosition: {x: -33.1, y: 0}
+  m_SizeDelta: {x: 54.1, y: 63.7}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7590188698881112908
 CanvasRenderer:
@@ -6585,7 +6584,7 @@ RectTransform:
   m_GameObject: {fileID: 7590188699074944039}
   m_LocalRotation: {x: -0, y: -0, z: -0.00000008429368, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.6, y: 0.6000003, z: 0.5999998}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 7590188699150468429}
   - {fileID: 7590188698881112910}
@@ -6594,8 +6593,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0.1668}
-  m_SizeDelta: {x: 0.03, y: 0.03}
+  m_AnchoredPosition: {x: 0, y: -21}
+  m_SizeDelta: {x: 8.97, y: 35.29}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7590188699074944036
 CanvasRenderer:
@@ -6742,17 +6741,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7590188699150468430}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 1, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 7590188699074944038}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 180}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.11, y: 0}
-  m_SizeDelta: {x: 0.18, y: 0.05}
+  m_AnchoredPosition: {x: 33.1, y: 0}
+  m_SizeDelta: {x: 54.1, y: 63.7}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7590188699150468403
 CanvasRenderer:
@@ -7116,9 +7115,9 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7590188699557635166}
-  m_LocalRotation: {x: 0.00000013671252, y: 1, z: 0.00000015064138, w: 0.000000025437869}
+  m_LocalRotation: {x: 0.00000009945961, y: 1, z: 0.000000057974805, w: -0.00000001181502}
   m_LocalPosition: {x: 0, y: 0, z: -0}
-  m_LocalScale: {x: 3999.9993, y: 3999.9993, z: 4166.6675}
+  m_LocalScale: {x: 8, y: 2, z: 1}
   m_Children:
   - {fileID: 7590188698773065399}
   - {fileID: 7590188699216676395}
@@ -7129,8 +7128,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -55, y: -714}
-  m_SizeDelta: {x: -850.01, y: 100}
+  m_AnchoredPosition: {x: -53.7, y: -5}
+  m_SizeDelta: {x: -850, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &1897886644689078423
 Canvas:
@@ -8212,15 +8211,15 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9081249899775583783}
   m_LocalRotation: {x: -0.00000008429369, y: -1, z: -0.00000023841852, w: -0.000000010536698}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.00025000004, y: 0.00025000004, z: 0.00023999996}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 0.12504375, y: 0.520625, z: 0.00023999996}
   m_Children: []
   m_Father: {fileID: 6782412305405042477}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0.1875}
+  m_AnchoredPosition: {x: 0, y: 21}
   m_SizeDelta: {x: 900, y: 200}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1585804728571509190


### PR DESCRIPTION
This change fixes an issue with the scale of elements inside the Item Spawner book. Both header elements had a scale of 3000 that would create a huge area that blocked selection in the scene view.

This change does not modify the actual visual scaling of elements inside the item book, and does not affect functionality.

###### Before
![image](https://user-images.githubusercontent.com/18744053/186494103-cb5ddbdf-c78e-45d7-8cec-437cf9691d98.png)

###### After
![image](https://user-images.githubusercontent.com/18744053/186494199-b4f730ad-382c-4ed5-8a0f-640d72ea9891.png)
