### PR TITLE
Add Navigation Sidebar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,8 @@ defaults:
       path: "" # an empty string here means all files in the project
     values:
       sass: _includes/extra/styles.scss
+      layout: default_sidebar 
+      
 
 twitter_username: 
 github_username:  KospY

--- a/_includes/extra/styles.scss
+++ b/_includes/extra/styles.scss
@@ -1,3 +1,12 @@
+/* Patch for elements with non-static positioning */
+
+html,
+body {
+    position: relative;
+    height: fit-content;
+}
+
+
 /* Remove blank sidebar */
 
 .content-wrap {
@@ -41,4 +50,54 @@
 
 .danger {
     border-color: #f29f97;
+}
+
+
+/* Content Sidebar */
+
+@for $level from 1 through 6 {
+    $depth: 1 - (($level - 1) / 6);
+    .snlevel-#{$level} {
+        font-size: 18px * max($depth, .73);
+        padding-left: 16px * ($level - 1);
+        $colorValue: ($depth * 255) - 150;
+        color: rgb($colorValue, $colorValue, $colorValue) !important;
+        @if $level==6 {
+            display: none;
+        }
+    }
+}
+
+.nav-sidebar {
+    min-width: 250px;
+    padding: 15px;
+    ul {
+        list-style-type: none;
+        padding-left: 0;
+    }
+}
+
+@media (max-width:1678px) {
+    .nav-sidebar {
+        width: 50%;
+        margin: auto;
+        background-color: hsl(0%, 0%, 95%);
+    }
+}
+
+
+/** Desktop view support */
+
+@media (min-width: 1678px) {
+    .nav-sidebar {
+        text-align: left;
+        right: 3%;
+        position: absolute;
+        height: 100%;
+        ul {
+            top: 20px;
+            position: sticky;
+            list-style-type: none;
+        }
+    }
 }

--- a/_layouts/default_sidebar.html
+++ b/_layouts/default_sidebar.html
@@ -1,0 +1,25 @@
+---
+layout: default 
+---
+
+<div class="nav-sidebar">
+    <ul>
+        <i class="fa fa-list" aria-hidden="true"></i>
+        <b>Index</b>
+    {% assign var = content | split: "<h" %}
+    {% for tag in var %}
+            {% assign depth = tag | split: "" | first %}
+            {% if "1234567890" contains depth %}
+            <li>
+                {{ tag | split: ">" | first | replace: depth, "<a" | replace: 'id="', 'href="#'}} class="snlevel-{{depth}}">
+                {{ tag | split: "</h" | first | split: ">" | last | truncate: 30}}
+                </a>
+            </li>
+            {% endif %} 
+    {% endfor %}
+
+    </ul>
+</div>
+
+
+{{ content }}


### PR DESCRIPTION
This change adds a simple dynamic navigation menu to the blank space on the right side of the wiki, allowing users to jump through the contents of the page faster.

This is done by extending the default jekyll layout provided by the rtd theme. The list constructed using liquid.

Mobile/tablet view is supported by modifying the position of the sidebar to the top of the page when the viewport goes below a certain width.

You can see the sidebar in action here:

https://user-images.githubusercontent.com/18744053/189742563-8e58dea6-1ea6-4c03-bb01-7f13bb3b1cbd.mp4

