### PR TITLE
Fix for the audioClip throwing a null reference for a bad call of method

### DIFF
--- a/Assets/SDK/Scripts/Audio/AudioContainer.cs
+++ b/Assets/SDK/Scripts/Audio/AudioContainer.cs
@@ -43,7 +43,8 @@ namespace ThunderRoad
 
             Type[] typeParams = { typeof(AudioClip), typeof(int), typeof(bool) };
 
-            MethodInfo method = audioUtilType.GetMethod("PlayClip", typeParams);
+            // It was not PlayClip but PlayPreviewClip
+            MethodInfo method = audioUtilType.GetMethod("PlayPreviewClip", typeParams);
 
             AudioClip clip = GetRandomAudioClip(sounds);
             object[] objParams = { clip, 0, false };


### PR DESCRIPTION
Fixed for the Audioclip not playing when clicking in the button "Test Random Audio Clip"