### PR TITLE
Fixed AssetBundleBuilder stripping custom shaders

### DIFF
--- a/Assets/SDK/Scripts/Assemblies/Editor/AssetBundleBuilder.cs
+++ b/Assets/SDK/Scripts/Assemblies/Editor/AssetBundleBuilder.cs
@@ -278,10 +278,13 @@ namespace ThunderRoad
                         bool haveWindowsLabel = false;
                         foreach (var entry in group.entries)
                         {
-                            Shader shader = AssetDatabase.LoadAssetAtPath<Shader>(entry.AssetPath);
-                            if (shader)
+                            if (thunderRoadAAGroupSchema.sharedBundle)
                             {
-                                shadersToStrip.Add(shader);
+                                Shader shader = AssetDatabase.LoadAssetAtPath<Shader>(entry.AssetPath);
+                                if (shader)
+                                {
+                                    shadersToStrip.Add(shader);
+                                }
                             }
                             if (entry.labels.Contains("Android"))
                             {


### PR DESCRIPTION
There appears to be a bug in the current Asset Bundle Builder. It is currently stripping out all shaders that are referenced inside of a bundle group rather than only if they are in a shared bundle.

This resolves custom shader exports if the shaders have been declared as an Addressable Asset.